### PR TITLE
Allow for symfony/http-client ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "juststeveking/uri-builder": "^1.1",
     "nyholm/psr7": "^1.3",
     "php-di/php-di": "^6.3",
-    "symfony/http-client": "^5.1"
+    "symfony/http-client": "^5.1|^6.0"
   },
   "require-dev": {
     "php-http/mock-client": "^1.4",


### PR DESCRIPTION
This is needed for comparability with newer versions of Laravel (11.5 PHP 8.3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Update**
  - Expanded compatibility for Symfony HTTP client to support versions 5.1 and 6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->